### PR TITLE
Shorten text to fit mobile screens

### DIFF
--- a/myelectric/myelectric.html
+++ b/myelectric/myelectric.html
@@ -143,7 +143,7 @@
                 </td>
                 
                 <td class="appbox">
-                    <div class="appbox-title">ALL TIME</div>
+                    <div class="appbox-title">ALL</div>
                     <div><span class="appbox-value u1a" style="color:#0699fa">£</span><span class="appbox-value" id="myelectric_alltime_kwh" style="color:#0699fa">---</span> <span class="units appbox-units u1b" style="color:#0779c1">kWh</span></div>
                     
                     <div style="padding-top:5px; color:#0779c1" class="appbox-units" ><span class="units u2a"></span><span id="myelectric_alltime_kwhd">---</span><span class="units u2b"> kWh/d</span></div>


### PR DESCRIPTION
For consideration Trystan - If 'ALL TIME' is shortened to 'ALL', the app renders much better on mobile devices.  See before and after screenshots below.  

![before](https://cloud.githubusercontent.com/assets/973580/10673263/c1a9f2e6-78ec-11e5-92e3-227cadffb04c.jpg)
![after](https://cloud.githubusercontent.com/assets/973580/10673265/c44412fc-78ec-11e5-90cb-f66184b8b77a.jpg)
