### PR TITLE
Stop the graph going off too far to the left or right when panning / zooming out

### DIFF
--- a/myelectric/myelectric.js
+++ b/myelectric/myelectric.js
@@ -94,6 +94,7 @@ var app_myelectric = {
             success: function(data_in) { meta = data_in; } 
         });
         app_myelectric.startalltime = meta.start_time;
+        view.first_data = meta.start_time * 1000;
         
         app_myelectric.reloadkwhd = true;
         

--- a/mysolarpv/mysolarpv.js
+++ b/mysolarpv/mysolarpv.js
@@ -394,6 +394,11 @@ var app_mysolarpv = {
         if (import_meta.start_time > latest_start_time) latest_start_time = import_meta.start_time;
         app_mysolarpv.latest_start_time = latest_start_time;
 
+        var earliest_start_time = solar_meta.start_time;
+        earliest_start_time = Math.min(use_meta.start_time, earliest_start_time);
+        earliest_start_time = Math.min(import_meta.start_time, earliest_start_time);
+        view.first_data = earliest_start_time * 1000;
+
         var timeWindow = (3600000*24.0*40);
         var end = +new Date;
         var start = end - timeWindow;

--- a/vis.helper.js
+++ b/vis.helper.js
@@ -2,14 +2,15 @@ var view =
 {
   'start':0,
   'end':0,
+  'first_data':0,
 
   'zoomout':function ()
   {
     var time_window = this.end - this.start;
     var middle = this.start + time_window / 2;
     time_window = time_window * 2;
-    this.start = middle - (time_window/2);
-    this.end = middle + (time_window/2);
+    this.start = Math.max(middle - (time_window/2), this.first_data);
+    this.end = Math.min(middle + (time_window/2), this.now());
   },
 
   'zoomin':function ()
@@ -25,6 +26,10 @@ var view =
   {
     var time_window = this.end - this.start;
     var shiftsize = time_window * 0.2;
+    var now = this.now();
+    if (this.end + shiftsize > now) {
+      shiftsize = now - this.end;
+    }
     this.start += shiftsize;
     this.end += shiftsize;
   },
@@ -33,6 +38,9 @@ var view =
   {
     var time_window = this.end - this.start;
     var shiftsize = time_window * 0.2;
+    if (this.start - shiftsize < this.first_data) {
+      shiftsize = this.start - this.first_data;
+    }
     this.start -= shiftsize;
     this.end -= shiftsize;
   },
@@ -71,6 +79,12 @@ var view =
       if (interval>3600*72) outinterval = 3600*72;
       
       return outinterval;
+  },
+
+  'now':function()
+  {
+    var date = new Date();
+    return date.getTime();
   }
 }
 


### PR DESCRIPTION
I noticed that when you zoom out or pan left & right, the graph can be made to go off too far.

This PR stops that from happening. I added a `first_data` parameter to `view` which is the left hand limit. The right hand limit is `(new Date()).getTime()`.

This PR also adds the necessary magic in the `mysolarpv` and `myelectric` apps to set the `first_data` parameter correctly.