### PR TITLE
Fix alignment of power-use values.

### DIFF
--- a/myelectric/myelectric.html
+++ b/myelectric/myelectric.html
@@ -16,12 +16,11 @@
         
         <table style="width:100%">
             <tr>
-                <td style="border:0; width:33%">
+                <td style="border:0; width:50%">
                     <div class="electric-title">POWER NOW</div>
                     <div class="power-value"><span id="myelectric_powernow">0</span></div>
                 </td>
-                <td style="text-align:center; border:0; width:33%"></td>
-                <td style="text-align:right; border:0; width:33%">
+                <td style="text-align:right; border:0;">
                     <div class="electric-title">USE TODAY</div>
                     <div class="power-value"><span id="myelectric_usetoday_units_a"></span><span id="myelectric_usetoday">0</span><span id="myelectric_usetoday_units_b" style="font-size:16px"> kWh</span></div>
                 </td>

--- a/myelectric/myelectric.js
+++ b/myelectric/myelectric.js
@@ -135,8 +135,6 @@ var app_myelectric = {
         if (width<=500) {
             $(".electric-title").css("font-size","16px");
             $(".power-value").css("font-size","38px");
-            $(".power-value").css("padding-top","12px");
-            $(".power-value").css("padding-bottom","8px");
             $(".midtext").css("font-size","14px");
             $(".units").hide();
             $(".visnav").css("padding-left","5px");
@@ -144,8 +142,6 @@ var app_myelectric = {
         } else if (width<=724) {
             $(".electric-title").css("font-size","18px");
             $(".power-value").css("font-size","52px");
-            $(".power-value").css("padding-top","22px");
-            $(".power-value").css("padding-bottom","12px");
             $(".midtext").css("font-size","18px");
             $(".units").show();
             $(".visnav").css("padding-left","8px");
@@ -153,8 +149,6 @@ var app_myelectric = {
         } else {
             $(".electric-title").css("font-size","22px");
             $(".power-value").css("font-size","85px");
-            $(".power-value").css("padding-top","40px");
-            $(".power-value").css("padding-bottom","20px");
             $(".midtext").css("font-size","20px");
             $(".units").show();
             $(".visnav").css("padding-left","8px");

--- a/myenergy/myenergy.js
+++ b/myenergy/myenergy.js
@@ -120,22 +120,16 @@ var app_myenergy = {
         if (width<=500) {
             $(".electric-title").css("font-size","16px");
             $(".power-value").css("font-size","38px");
-            $(".power-value").css("padding-top","12px");
-            $(".power-value").css("padding-bottom","8px");
             $(".midtext").css("font-size","14px");
             $(".balanceline").hide();
         } else if (width<=724) {
             $(".electric-title").css("font-size","18px");
             $(".power-value").css("font-size","52px");
-            $(".power-value").css("padding-top","22px");
-            $(".power-value").css("padding-bottom","12px");
             $(".midtext").css("font-size","18px");
             $(".balanceline").show();
         } else {
             $(".electric-title").css("font-size","22px");
             $(".power-value").css("font-size","85px");
-            $(".power-value").css("padding-top","40px");
-            $(".power-value").css("padding-bottom","20px");
             $(".midtext").css("font-size","20px");
             $(".balanceline").show();
         }

--- a/mysolarpv/mysolarpv.js
+++ b/mysolarpv/mysolarpv.js
@@ -142,8 +142,6 @@ var app_mysolarpv = {
         if (width<=500) {
             $(".electric-title").css("font-size","16px");
             $(".power-value").css("font-size","32px");
-            $(".power-value").css("padding-top","12px");
-            $(".power-value").css("padding-bottom","8px");
             $(".midtext").css("font-size","14px");
             $(".balanceline").hide();
             $(".vistimeW").hide();
@@ -152,8 +150,6 @@ var app_mysolarpv = {
         } else if (width<=724) {
             $(".electric-title").css("font-size","18px");
             $(".power-value").css("font-size","52px");
-            $(".power-value").css("padding-top","22px");
-            $(".power-value").css("padding-bottom","12px");
             $(".midtext").css("font-size","18px");
             $(".balanceline").show();
             $(".vistimeW").show();
@@ -162,8 +158,6 @@ var app_mysolarpv = {
         } else {
             $(".electric-title").css("font-size","22px");
             $(".power-value").css("font-size","85px");
-            $(".power-value").css("padding-top","40px");
-            $(".power-value").css("padding-bottom","20px");
             $(".midtext").css("font-size","20px");
             $(".balanceline").show();
             $(".vistimeW").show();

--- a/mysolarpvdivert/mysolarpvdivert.js
+++ b/mysolarpvdivert/mysolarpvdivert.js
@@ -160,8 +160,6 @@ var app_mysolarpvdivert = {
         if (width<=500) {
             $(".electric-title").css("font-size","16px");
             $(".power-value").css("font-size","32px");
-            $(".power-value").css("padding-top","12px");
-            $(".power-value").css("padding-bottom","8px");
             $(".statstable").css("border-spacing","4px");
             $(".statsbox-title").css("font-size","14px");
             $(".statsbox-title").css("padding-bottom","4px");
@@ -178,8 +176,6 @@ var app_mysolarpvdivert = {
         } else if (width<=724) {
             $(".electric-title").css("font-size","18px");
             $(".power-value").css("font-size","52px");
-            $(".power-value").css("padding-top","22px");
-            $(".power-value").css("padding-bottom","12px");
             $(".statstable").css("border-spacing","8px");
             $(".statsbox-title").css("font-size","16px");
             $(".statsbox-title").css("padding-bottom","8px");
@@ -196,8 +192,6 @@ var app_mysolarpvdivert = {
         } else {
             $(".electric-title").css("font-size","22px");
             $(".power-value").css("font-size","85px");
-            $(".power-value").css("padding-top","40px");
-            $(".power-value").css("padding-bottom","20px");
             $(".statstable").css("border-spacing","10px");
             $(".statsbox-title").css("font-size","20px");
             $(".statsbox-title").css("padding-bottom","15px");

--- a/style.css
+++ b/style.css
@@ -33,8 +33,7 @@ hr {
     font-weight:bold; 
     font-size:100px; 
     color:#0699fa; 
-    padding-top:45px;
-    padding-bottom:30px;
+    line-height: 1.1;
 }
 
 .kwh-value {


### PR DESCRIPTION
Previously, padding was used to try to get these the correct height.  However,
the height of the div ended up being different between the 'Power Now' and
'Used Today' values because of different font sizes used within the Used Today
div (for the 'kWh' unit).  The incorrect height of these lines was coming from
the emoncms 'bootstrap' CSS setting line-height to 20px.

Newer bootstrap.css replaces this with a multiplier of approx 1.4 instead of a
fixed values, but updating bootstrap CSS is a significant change as it is
substantially different than when first imported. and will alter the layout of
all pages.  Instead, just set the line height we'd like for the 'power-use'
class to correct this problem, and then remove the padding since it is no
longer needed.

Fixes #22.

![small](https://cloud.githubusercontent.com/assets/4905783/23581065/5873a734-0105-11e7-9691-dd978e10dda8.png)
![medium](https://cloud.githubusercontent.com/assets/4905783/23581066/5873c62e-0105-11e7-8e9d-46012e82e7bf.png)
![large](https://cloud.githubusercontent.com/assets/4905783/23581067/5873d75e-0105-11e7-9b55-ed54e3245cc9.png)