### PR TITLE
Add option to use a "name" subaction to view apps

### DIFF
--- a/app_controller.php
+++ b/app_controller.php
@@ -93,7 +93,7 @@ function app_controller()
         {
             $applist = $appconfig->applist($userid);
             
-            if (isset($route->subaction)) {
+            if ($route->subaction) {
                 $userappname = $route->subaction;
             } else {
                 $userappname = get("name");

--- a/app_controller.php
+++ b/app_controller.php
@@ -92,7 +92,12 @@ function app_controller()
         if ($userid)
         {
             $applist = $appconfig->applist($userid);
-            $userappname = get("name");
+            
+            if (isset($route->subaction)) {
+                $userappname = $route->subaction;
+            } else {
+                $userappname = get("name");
+            }
             
             if (!isset($applist->$userappname)) {
                 foreach ($applist as $key=>$val) { $userappname = $key; break; }


### PR DESCRIPTION
For consistency with the Dashboard api and for the option to use tidier and more memorable urls eg https://emoncms.org/app/view/solar, the existing `name=` method is still there and used if no subaction is defined.