### PR TITLE
Fix View History -> View All

### DIFF
--- a/apps/mysolarpv.php
+++ b/apps/mysolarpv.php
@@ -545,7 +545,7 @@ function powergraph_events() {
 function init_bargraph() {
     bargraph_initialized = true;
     // Fetch the start_time covering all kwh feeds - this is used for the 'all time' button
-    var latest_start_time = 0;
+    latest_start_time = 0;
     var solar_meta = feed.getmeta(config.app.solar_kwh.value);
     var use_meta = feed.getmeta(config.app.use_kwh.value);
     var import_meta = feed.getmeta(config.app.import_kwh.value);

--- a/apps/mysolarpvdivert.php
+++ b/apps/mysolarpvdivert.php
@@ -817,7 +817,15 @@ function powergraph_events() {
 
             for (i = 0; i < powerseries.length; i++) {
                 var series = powerseries[i];
-                tooltip_items.push([series.label.toUpperCase(), series.data[item.dataIndex][1].toFixed(1), "W"]);
+                if (series.label.toUpperCase()=="BALANCE") {
+                    tooltip_items.push([series.label.toUpperCase(), series.data[item.dataIndex][1].toFixed(1), "kWh"]);
+                } else {
+                    if ( series.data[item.dataIndex][1] >= 1000) {
+                        tooltip_items.push([series.label.toUpperCase(), series.data[item.dataIndex][1].toFixed(0)/1000 , "kW"]);
+                    } else {
+                        tooltip_items.push([series.label.toUpperCase(), series.data[item.dataIndex][1].toFixed(0), "W"]);
+                    }
+                }
             }
             show_tooltip(pos.pageX+10, pos.pageY+5, tooltip_items);
         } else {

--- a/apps/mysolarpvdivert.php
+++ b/apps/mysolarpvdivert.php
@@ -862,7 +862,7 @@ function powergraph_events() {
 function init_bargraph() {
     bargraph_initialized = true;
     // Fetch the start_time covering all kwh feeds - this is used for the 'all time' button
-    var latest_start_time = 0;
+    latest_start_time = 0;
     var solar_meta = feed.getmeta(config.app.solar_kwh.value);
     var use_meta = feed.getmeta(config.app.use_kwh.value);
     var divert_meta = feed.getmeta(config.app.divert_kwh.value);


### PR DESCRIPTION
For both MySolarPV and MySolarPVDivert when selecting View history -> View all used to show no data for me:
![image](https://user-images.githubusercontent.com/33792140/34908501-7981a9be-f888-11e7-9a67-d244f914bafc.png)

Changed init_bargraph() to **not** initialise a local variable and thereby prevent the graph displaying the data. Now produces:
![image](https://user-images.githubusercontent.com/33792140/34908516-bfdc66c4-f888-11e7-8647-6bfbde552ef9.png)
