### PR TITLE
Fatal Error - query on out dated database

### DIFF
--- a/app_model.php
+++ b/app_model.php
@@ -201,7 +201,7 @@ class AppConfig
     private function get($userid) 
     {
         $result = $this->mysqli->query("SELECT `data` FROM app_config WHERE `userid`='$userid'");
-        if ($row = $result->fetch_object()) {
+        if ($result && $row = $result->fetch_object()) {
             $applist = json_decode($row->data);
             if (gettype($applist)=="array" || $applist===null) $applist = new stdClass();
         } else {


### PR DESCRIPTION
fixes issue #47 

@borpin - the raised issue was a while back, but the code in the stable branch that matches the error line is still in the master branch. - `AppConfig->get()`  now in (app_model.php)

To fix this I checked for successful database query before running fetch_object()

I've not tested this successfully yet as I can't re-create the error. The code I added shouldn't cause any issues.

This branch in this pull request is based on the **master** branch not the **stable** branch.