### PR TITLE
Fix errors when internet is disconnected / flakey

### DIFF
--- a/Lib/feed.js
+++ b/Lib/feed.js
@@ -5,16 +5,18 @@ var feed = {
         var apikeystr = "";
         if (apikey!="") apikeystr = "?apikey="+apikey;
         
-        var feeds = {};
+        var feeds = null;
         $.ajax({                                      
             url: path+"feed/list.json"+apikeystr,
             dataType: 'json',
             async: true,                      
             success: function(result) {
+                feeds = result; 
                 if (!result || result===null || result==="" || result.constructor!=Array) {
                     console.log("ERROR","feed.listbyidasync invalid response: "+result);
+                    f(null);
+                    return;
                 }
-                feeds = result; 
                 
                 var byid = {};
                 for (z in feeds) byid[feeds[z].id] = feeds[z];
@@ -28,16 +30,17 @@ var feed = {
         var apikeystr = "";
         if (apikey!="") apikeystr = "?apikey="+apikey;
         
-        var feeds = {};
+        var feeds = null;
         $.ajax({                                      
             url: path+"feed/list.json"+apikeystr,
             dataType: 'json',
             async: false,                      
             success: function(result) {
+                feeds = result; 
                 if (!result || result===null || result==="" || result.constructor!=Array) {
                     console.log("ERROR","feed.list invalid response: "+result);
+                    feeds = null;
                 }
-                feeds = result; 
             } 
         });
         
@@ -46,6 +49,7 @@ var feed = {
     
     listbyid: function() {
         var feeds = feed.list();
+        if (feeds === null) { return null; }
         var byid = {};
         for (z in feeds) byid[feeds[z].id] = feeds[z];
         return byid;
@@ -53,6 +57,7 @@ var feed = {
     
     listbyname: function() {
         var feeds = feed.list();
+        if (feeds === null) { return null; }
         var byname = {};
         for (z in feeds) byname[feeds[z].name] = feeds[z];
         return byname;

--- a/apps/OpenEnergyMonitor/myelectric/myelectric.php
+++ b/apps/OpenEnergyMonitor/myelectric/myelectric.php
@@ -382,6 +382,7 @@ function fastupdate()
     // 1) Get last value of feeds
     // --------------------------------------------------------------------
     feeds = feed.listbyid();
+    if (feeds === null) { return; }
     
     // set the power now value
     if (viewmode=="energy") {

--- a/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
+++ b/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
@@ -285,6 +285,7 @@ function hide() {
 function updater()
 {
     feed.listbyidasync(function(result){
+        if (result === null) { return; }
         
         for (var key in config.app) {
             if (config.app[key].value) feeds[key] = result[config.app[key].value];

--- a/apps/OpenEnergyMonitor/myenergy/myenergy.php
+++ b/apps/OpenEnergyMonitor/myenergy/myenergy.php
@@ -286,6 +286,7 @@ function livefn()
     lastupdate = now;
     
     var feeds = feed.listbyid();
+    if (feeds === null) { return; }
     var solar_now = 0;
     if (config.app.solar.value)
         solar_now = parseInt(feeds[config.app.solar.value].value);

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -326,6 +326,7 @@ function clear()
 function updater()
 {
     feed.listbyidasync(function(result){
+        if (result === null) { return; }
         
         for (var key in config.app) {
             if (config.app[key].value) feeds[key] = result[config.app[key].value];

--- a/apps/OpenEnergyMonitor/mysolarpv/mysolarpv.php
+++ b/apps/OpenEnergyMonitor/mysolarpv/mysolarpv.php
@@ -341,6 +341,7 @@ function livefn()
     lastupdate = now;
     
     var feeds = feed.listbyid();
+    if (feeds === null) { return; }
     var solar_now = parseInt(feeds[config.app.solar.value].value);
     var use_now = parseInt(feeds[config.app.use.value].value);
 

--- a/apps/OpenEnergyMonitor/mysolarpvdivert/mysolarpvdivert.php
+++ b/apps/OpenEnergyMonitor/mysolarpvdivert/mysolarpvdivert.php
@@ -553,6 +553,7 @@ function livefn()
     lastupdate = now;
     
     var feeds = feed.listbyid();
+    if (feeds === null) { return; }
     var solar_now = parseInt(feeds[config.app.solar.value].value);
     var use_now = parseInt(feeds[config.app.use.value].value);
     var divert_now = parseInt(feeds[config.app.divert.value].value);

--- a/apps/OpenEnergyMonitor/timeofuse/timeofuse.php
+++ b/apps/OpenEnergyMonitor/timeofuse/timeofuse.php
@@ -293,6 +293,7 @@ function hide() {
 function updater()
 {
     feed.listbyidasync(function(result){
+        if (result === null) { return; }
         
         for (var key in config.app) {
             if (config.app[key].value) feeds[key] = result[config.app[key].value];

--- a/apps/OpenEnergyMonitor/timeofuse2/timeofuse2.php
+++ b/apps/OpenEnergyMonitor/timeofuse2/timeofuse2.php
@@ -375,6 +375,8 @@ function hide() {
 function updater()
 {
     feed.listbyidasync(function(result){
+        if (result === null) { return; }
+
         for (var key in config.app) {
             if (config.app[key].value) feeds[key] = result[config.app[key].value];
         }

--- a/apps/OpenEnergyMonitor/timeofusecl/timeofusecl.php
+++ b/apps/OpenEnergyMonitor/timeofusecl/timeofusecl.php
@@ -393,6 +393,8 @@ function hide() {
 function updater()
 {
     feed.listbyidasync(function(result){
+        if (result === null) { return; }
+
         for (var key in config.app) {
             if (config.app[key].value) feeds[key] = result[config.app[key].value];
         }


### PR DESCRIPTION
If the internet is disconnected, flakey or something just goes wrong,
then apps show an error (see #60). This fixes it by returning `null`
from the list APIs and then catching that case and just returning from
the update function.

Fixes #60.