### PR TITLE
Fix not working when feed is <24 hours old

### DIFF
--- a/apps/OpenEnergyMonitor/myelectric/myelectric.php
+++ b/apps/OpenEnergyMonitor/myelectric/myelectric.php
@@ -554,8 +554,17 @@ function slowupdate()
     }
     
     daily = [];
-    
-    if (data.length>0) {
+
+    if (data.length==0) {
+        // If empty, then it's a new feed and we can safely append today's value.
+        // Also append a fake value for the day before so that the calculations work.
+        if (feeds[use_kwh]!=undefined) {
+            var d = new Date();
+            d.setHours(0,0,0,0);
+            data.push([d.getTime(),0]);
+            data.push([d.getTime()+(interval*1000),feeds[use_kwh].value*1.0]);
+        }
+    } else {
         var lastday = data[data.length-1][0];
         
         var d = new Date();
@@ -568,15 +577,14 @@ function slowupdate()
                 data.push([next,feeds[use_kwh].value*1.0]);
             }
         }
+    }
     
-        // Calculate the daily totals by subtracting each day from the day before
-        
-        for (var z=1; z<data.length; z++)
-        {
-          var time = data[z-1][0];
-          var diff = (data[z][1]-data[z-1][1]);
-          daily.push([time,diff*scale]);
-        }
+    // Calculate the daily totals by subtracting each day from the day before
+    for (var z=1; z<data.length; z++)
+    {
+      var time = data[z-1][0];
+      var diff = (data[z][1]-data[z-1][1]);
+      daily.push([time,diff*scale]);
     }
     
     var usetoday_kwh = 0;

--- a/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
+++ b/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
@@ -574,7 +574,14 @@ function bargraph_load(start,end)
     
     data["use_kwhd"] = [];
     
-    if (elec_data.length>0) {
+    if (elec_data.length==0) {
+        // If empty, then it's a new feed and we can safely append today's value.
+        // Also append a fake value for the day before so that the calculations work.
+        var d = new Date();
+        d.setHours(0,0,0,0);
+        elec_data.push([d.getTime(),0]);
+        elec_data.push([d.getTime()+(interval*1000),feeds["use_kwh"].value]);
+    } else {
         var lastday = elec_data[elec_data.length-1][0];
         
         var d = new Date();
@@ -585,7 +592,9 @@ function bargraph_load(start,end)
             var next = elec_data[elec_data.length-1][0] + (interval*1000);
             elec_data.push([next,feeds["use_kwh"].value]);
         }
- 
+    }
+
+    if (elec_data.length>1) {
         var total_kwh = 0; 
         var n = 0;
         // Calculate the daily totals by subtracting each day from the day before
@@ -605,7 +614,7 @@ function bargraph_load(start,end)
             $("#kwh_today").html(kwh_today.toFixed(1)+"<span class='units'>kWh</span>");
         } else {
             $("#kwh_today").html(config.app.currency.value+(kwh_today*config.app.unitcost.value).toFixed(2));
-        }
+	}
     }
     
     bargraph_series = [];


### PR DESCRIPTION
This fixes the long-standing bug where MyElectric and MyElectric2 don't
work properly if the feed you use for kwh values is <24 hours old. It
simply adds in the relevant data for today midnight and tomorrow
midnight to make the calculations work.

Fixes #15.