### PR TITLE
used "use" when "use_kwhd" not available

### DIFF
--- a/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
+++ b/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
@@ -349,7 +349,15 @@ $('#placeholder').bind("plothover", function (event, pos, item) {
 
             $("#tooltip").remove();
             var itemTime = item.datapoint[0];
-            var elec_kwh = data.use_kwhd[z] ? data.use_kwhd[z][1]: data.use[z][1];
+
+            var elec_kwh, unit;
+            if (data.use_kwhd[z]) {
+                unit = "kWh";
+                elec_kwh = data.use_kwhd[z][1];
+            } else {
+                unit = "W";
+                elec_kwh = data.use[z][1];
+            }
 
             var d = new Date(itemTime);
             var days = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
@@ -358,9 +366,9 @@ $('#placeholder').bind("plothover", function (event, pos, item) {
             
             var text = "";
             if (viewcostenergy=="energy") {
-                text = date+"<br>"+(elec_kwh).toFixed(1)+" kWh";
+                text = date+"<br>"+(elec_kwh).toFixed(1)+" " + unit;
             } else {
-                text = date+"<br>"+(elec_kwh).toFixed(1)+" kWh ("+config.app.currency.value+(elec_kwh*config.app.unitcost.value).toFixed(2)+")";
+                text = date+"<br>"+(elec_kwh).toFixed(1)+" " + unit + " ("+config.app.currency.value+(elec_kwh*config.app.unitcost.value).toFixed(2)+")";
             }
             
             tooltip(item.pageX, item.pageY, text, "#fff");

--- a/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
+++ b/apps/OpenEnergyMonitor/myelectric2/myelectric2.php
@@ -349,7 +349,7 @@ $('#placeholder').bind("plothover", function (event, pos, item) {
 
             $("#tooltip").remove();
             var itemTime = item.datapoint[0];
-            var elec_kwh = data["use_kwhd"][z][1];
+            var elec_kwh = data.use_kwhd[z] ? data.use_kwhd[z][1]: data.use[z][1];
 
             var d = new Date(itemTime);
             var days = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];


### PR DESCRIPTION
fix #62 
`plothover` event now checks for value before displaying the tooltip on the single day

![delwedd](https://user-images.githubusercontent.com/1466013/51940053-e31a4a00-2408-11e9-9cd4-effe0531e918.png)

@TrystanLea  - is this change correct? is the value in Watts when looking at the rolling total?