### PR TITLE
mysolarpv.php number format USE and SOLAR at low power

### DIFF
--- a/apps/OpenEnergyMonitor/mysolarpv/mysolarpv.php
+++ b/apps/OpenEnergyMonitor/mysolarpv/mysolarpv.php
@@ -491,8 +491,16 @@ function draw_powergraph() {
         
         t += interval;
     }
-    $(".total_solar_kwh").html(total_solar_kwh.toFixed(1));
-    $(".total_use_kwh").html((total_use_kwh).toFixed(1));
+    if (total_solar_kwh < 1) {
+    	$(".total_solar_kwh").html(total_solar_kwh.toFixed(2));
+    } else {
+    	$(".total_solar_kwh").html(total_solar_kwh.toFixed(1));
+    }
+    if (total_use_kwh < 1) {
+    	$(".total_use_kwh").html((total_use_kwh).toFixed(2));
+    } else {
+    	$(".total_use_kwh").html((total_use_kwh).toFixed(1));
+    }
     
     $(".total_use_direct_kwh").html((total_use_direct_kwh).toFixed(1));
 
@@ -699,8 +707,16 @@ function bargraph_events(){
             var export_kwhd = export_kwhd_data[z][1];
             var imported_kwhd = use_kwhd-solarused_kwhd;
             
-            $(".total_solar_kwh").html((solar_kwhd).toFixed(1));
-            $(".total_use_kwh").html((use_kwhd).toFixed(1));
+            if (solar_kwhd < 1) {
+                $(".total_solar_kwh").html((solar_kwhd).toFixed(2));
+            } else {
+                $(".total_solar_kwh").html((solar_kwhd).toFixed(1));
+            }
+            if (use_kwhd < 1) {
+                $(".total_use_kwh").html((use_kwhd).toFixed(2));
+            } else {
+                $(".total_use_kwh").html((use_kwhd).toFixed(1));
+            }
             
             $(".total_use_direct_kwh").html((solarused_kwhd).toFixed(1));
             


### PR DESCRIPTION
Show 2 numbers after the decimal points for USE and SOLAR when values are under 1 KWH in draw_powergraph() and bargraph_events(). 

Makes it easier to see that something is happening in low power and high zoom situations.