### PR TITLE
Fix/hide view menu item

### DIFF
--- a/app_menu.php
+++ b/app_menu.php
@@ -53,6 +53,6 @@
     $menu['sidebar']['apps'][] = array(
         'text' => _('View'),
         'path' => 'app/view',
-        'li_class'=>'hide',
+        'li_class'=>'d-none',
         'order'=> 99
     );


### PR DESCRIPTION
fix #86 
this will stop the "View" link from appearing in the sidebar. This link is required to enable the user to view the default app `app/view` and for the correct sidebar to be shown