### PR TITLE
app.css doesn't pass a version

### DIFF
--- a/app_controller.php
+++ b/app_controller.php
@@ -11,14 +11,15 @@
 
 // no direct access
 defined('EMONCMS_EXEC') or die('Restricted access');
-$v = 9;
+
 function app_controller()
 {
-    global $mysqli,$path,$session,$route,$user,$app_settings,$v;
+    global $mysqli,$path,$session,$route,$user,$app_settings;
     
     $result = false;
 
     require_once "Modules/app/app_model.php";
+    $v = 9;
     $appconfig = new AppConfig($mysqli, $app_settings);
     $appavail = $appconfig->get_available();
 


### PR DESCRIPTION
Having a look at the html output of Cost Comparrsion it can be seen that app.css is expecting to have a version number to assist with the caching of the file.

```
<main class="content-container container-fluid">
<link href="http://emonpi/emoncms/Modules/app/Views/css/app.css?v=" rel="stylesheet">
<link href="http://emonpi/emoncms/Modules/app/Views/css/config.css?v=7" rel="stylesheet">
```

The code is generated in app_controller.php which on line 14 shows `$v = 9;` however a glance through the code reveals this would't be parsed due to line 21 `require_once "Modules/app/app_model.php";`

I have moved line 14 below line 21 and removed $v from the global reference (It's not used anywhere else on the page)