### PR TITLE
Fix: mysolarpv graph not correctly updated.

### DIFF
--- a/apps/OpenEnergyMonitor/mysolarpv/mysolarpv.php
+++ b/apps/OpenEnergyMonitor/mysolarpv/mysolarpv.php
@@ -376,7 +376,9 @@ function livefn()
     var use_now = parseInt(feeds[config.app.use.value].value);
 
     if (autoupdate) {
-        var updatetime = feeds[config.app.solar.value].time;
+        var updatetimesolar = feeds[config.app.solar.value].time;
+        var updatetimeuse = feeds[config.app.use.value].time;
+        var updatetime = Math.max(updatetimesolar, updatetimeuse);
         timeseries.append("solar",updatetime,solar_now);
         timeseries.trim_start("solar",view.start*0.001);
         timeseries.append("use",updatetime,use_now);


### PR DESCRIPTION
In my setup the solar feed only gets updates if there is a change on the PV output. This means during daytime the solar feed constantly gets updates. But during night time there is no update as the output stays at 0 all the time.

With that setup the graph of the MySolarPv app is correctly updated during day time. But during night time there is no update on both use and solar. Both graphs show 0 at the end. When the graph is reloaded by a browser refresh then the use graph is correctly shown.

The reason for this is that the time of the last update on the solar feed is used to update both the solar and the use timeseries. If this is changed so that the timeseries are updated with the max time of both feeds then the use graph is correctly updated also if there is no change on the solar feed.