### PR TITLE
added caching param to list.json requests

### DIFF
--- a/Lib/feed.js
+++ b/Lib/feed.js
@@ -34,6 +34,7 @@ var feed = {
         $.ajax({                                      
             url: path+"feed/list.json"+apikeystr,
             dataType: 'json',
+            cache: false,
             async: false,                      
             success: function(result) {
                 feeds = result; 


### PR DESCRIPTION
adding the `cache: true` param to the js requests for `list.json` sends the current time as an additional parameter called `_`. this should stop older browsers from caching responses from the api as there will be a different value sent with each request.

eg: ?apikey=[XXXXXXXXX]&_=1577707087415

I cannot test with older versions of IE on windows. Could anybody test this on IE 8+ and let me know if this stops the caching...?