### PR TITLE
Remove call to non existent css file

### DIFF
--- a/app_controller.php
+++ b/app_controller.php
@@ -111,7 +111,6 @@ function app_controller()
     else if ($route->action == "new" && $session['write']) {
         $applist = $appconfig->get_list($session['userid']);
         $route->format = "html";
-        $result = "<link href='".$path."Modules/app/Views/css/pagenav.css?v=1' rel='stylesheet'>";
         $result .= "<link href='".$path."Modules/app/Views/css/app.css?v=".$v."' rel='stylesheet'>";
         $result .= view("Modules/app/Views/app_view.php", array("apps"=>$appavail));
     }


### PR DESCRIPTION
Within App, navigate to new app and have a look in the browser console, a 404 is seen for pagenav.css
Do a search of emoncms github only 1 reference to the file is found
Apply this patch and check the console - No 404 errors seen