### PR TITLE
Add feed for highlighting heat cycles, plus summary stats for heating

### DIFF
--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -975,8 +975,16 @@ function powergraph_load()
             } else {
                 $("#dhw_cop").html("~");
             }
-            let cop = (feedstats["heatpump_heat"].kwh - dhw_heat_kwh) / (feedstats["heatpump_elec"].kwh - dhw_elec_kwh);
-            $("#exclude_dhw_cop").html(cop.toFixed(2));
+
+            let ch_elec_kwh = feedstats["heatpump_elec"].kwh - dhw_elec_kwh - standby_kwh
+            let ch_heat_kwh = feedstats["heatpump_heat"].kwh - dhw_heat_kwh
+            if (ch_elec_kwh > 0) {
+                $("#ch_cop").html((ch_heat_kwh / ch_elec_kwh).toFixed(2));
+            } else {
+                $("#ch_cop").html("~");
+            }
+            $("#ch_elec_kwh").html(ch_elec_kwh.toFixed(3));
+            $("#ch_heat_kwh").html(ch_heat_kwh.toFixed(3));
         }
     }
     
@@ -987,7 +995,6 @@ function powergraph_load()
       "heatpump_returnT":"Return temperature",
       "heatpump_outsideT":"Outside temperature",
       "heatpump_roomT":"Room temperature",
-      "heatpump_dwh":"Heating hot water tank",
       "heatpump_flowrate":"Flow rate"
     }
     

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -27,6 +27,7 @@ config.app = {
     "heatpump_roomT":{"type":"feed", "autoname":"heatpump_roomT", "engine":5, "optional":true, "description":"Room temperature"},
     "heatpump_flowrate":{"type":"feed", "autoname":"heatpump_flowrate", "engine":5, "optional":true, "description":"Flow rate"},
     "heatpump_dhw":{"type":"feed", "autoname":"heatpump_dhw", "engine":5, "optional":true, "description":"Heating Hot Water"},
+    "heatpump_ch":{"type":"feed", "autoname":"heatpump_ch", "engine":5, "optional":true, "description":"Central Heating"},
     "start_date":{"type":"value", "default":0, "name": "Start date", "description":_("Start date for all time values (unix timestamp)")},
 };
 config.feeds = feed.list();
@@ -392,6 +393,7 @@ $('#placeholder').bind("plothover", function (event, pos, item) {
                 else if (item.series.label=="OutsideT") { name = "Outside"; unit = "°C"; dp = 1; }
                 else if (item.series.label=="RoomT") { name = "Room"; unit = "°C"; dp = 1; }
                 else if (item.series.label=="DHW") { name = "Hot Water"; unit = ""; dp = 0; }
+                else if (item.series.label=="CH") { name = "Central Heating"; unit = ""; dp = 0; }
                 else if (item.series.label=="Electric") { name = "Elec"; unit = "W"; }
                 else if (item.series.label=="Heat") { name = "Heat"; unit = "W"; }
                 else if (item.series.label=="Carnot Heat") { name = "Carnot Heat"; unit = "W"; }
@@ -583,6 +585,16 @@ function powergraph_load()
             powergraph_series.push({label:"DHW", data:remove_null_values(data["heatpump_dhw"]), yaxis:4, color:"#88F", lines:style});
         } else {
             powergraph_series.push({label:"DHW", data:data["heatpump_dhw"], yaxis:4, color:"#88F", lines:style});
+        }
+    }
+    if (feeds["heatpump_ch"]!=undefined) {
+        data["heatpump_ch"] = feed.getdata(feeds["heatpump_ch"].id,view.start,view.end,view.interval,0,0,skipmissing,limitinterval);
+
+        let style = {lineWidth: 0, show:true, fill:0.15};
+        if (all_same_interval) {
+            powergraph_series.push({label:"CH", data:remove_null_values(data["heatpump_ch"]), yaxis:4, color:"#FD8", lines:style});
+        } else {
+            powergraph_series.push({label:"CH", data:data["heatpump_ch"], yaxis:4, color:"#FD8", lines:style});
         }
     }
     if (feeds["heatpump_flowT"]!=undefined) { 

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -120,12 +120,16 @@
         
         <div id="dhw_stats" style="display: none">
           <hr style="margin:10px 0px 10px 0px">
-          <p><b>Hot Water</b></p>
-          <p>Electricity consumed: <span id="dhw_elec_kwh"></span> kWh
-          &gt; heat produced: <span id="dhw_heat_kwh"></span> kWh
-          = COP <b><span id="dhw_cop"></span></b>
-          | COP excluding DHW: <b><span id="exclude_dhw_cop"></span></b>
-        </p>
+          <p><b>Heating</b>:
+            Electricity consumed: <span id="ch_elec_kwh"></span> kWh
+            &raquo; heat produced: <span id="ch_heat_kwh"></span> kWh
+            = COP <b><span id="ch_cop"></span></b>
+          </p>
+          <p><b>Hot Water</b>:
+            Electricity consumed: <span id="dhw_elec_kwh"></span> kWh
+            &raquo; heat produced: <span id="dhw_heat_kwh"></span> kWh
+            = COP <b><span id="dhw_cop"></span></b>
+          </p>
         </div>
         
         <hr style="margin:10px 0px 10px 0px">
@@ -258,4 +262,4 @@ var session_write = <?php echo $session['write']; ?>;
 config.name = "<?php echo $name; ?>";
 config.db = <?php echo json_encode($config); ?>;
 </script>
-<script type="text/javascript" src="<?php echo $path; ?>Modules/app/apps/OpenEnergyMonitor/myheatpump/myheatpump.js?v=62"></script>
+<script type="text/javascript" src="<?php echo $path; ?>Modules/app/apps/OpenEnergyMonitor/myheatpump/myheatpump.js?v=63"></script>


### PR DESCRIPTION
Users can add `heatpump_ch` feed to highlight heating cycles separately, painted with a pale yellow.  
Feed is not used for any other computation at this time. Standby still uses a threshold.

![image](https://github.com/emoncms/app/assets/75039652/8c7ada6d-ae37-4a85-ac3e-7c778e9cc72c)

Separate stats shown underneath for heating and hot water.  
Does not require `heatpump_ch` feed, as it only needs to know hot water and standby consumption.

![image](https://github.com/emoncms/app/assets/75039652/f4dee8f4-94d7-4e17-a058-8423269ce8b9)
