### PR TITLE
Tweaks to My Heatpump app

### DIFF
--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -467,6 +467,15 @@ $('.bargraph-week').click(function () {
     bargraph_draw();
 });
 
+$('.bargraph-quarter').click(function () {
+    var timeWindow = (3600000*24.0*91);
+    var end = (new Date()).getTime();
+    var start = end - timeWindow;
+    if (start<(start_time*1000)) start = start_time * 1000;
+    bargraph_load(start,end);
+    bargraph_draw();
+});
+
 $('.bargraph-month').click(function () {
     var timeWindow = (3600000*24.0*30);
     var end = (new Date()).getTime();

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -1104,7 +1104,7 @@ function powergraph_draw()
             margin:{top:30}
         },
         selection: { mode: "x" },
-        legend:{position:"NW", noColumns:7}
+        legend:{position:"NW", noColumns:10}
     }
     if ($('#placeholder').width()) {
         $.plot($('#placeholder'),powergraph_series,options);

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -155,7 +155,7 @@ function show()
 
     // If this is a new dashboard there will be less than a days data 
     // show power graph directly in this case
-    if (((end*0.001)-start_time)<86400*3 || viewmode=="powergraph") {
+    if (((end*0.001)-start_time)<86400*3 || viewmode=="powergraph" || location.hash == "#power") {
         var timeWindow = (end - start_time*1000);
         if (timeWindow>(86400*3*1000)) timeWindow = 86400*1*1000;
         var start = end - timeWindow;
@@ -167,6 +167,12 @@ function show()
         $(".powergraph-navigation").show();
         powergraph_draw();
         $("#advanced-toggle").show();
+
+        if (location.hash == "#power") {
+          // auto-expand detail
+          $("#advanced-block").show();
+          $("#advanced-toggle").html("HIDE DETAIL");
+        }
     } else {
         var timeWindow = (3600000*24.0*30);
         var start = end - timeWindow;
@@ -302,22 +308,6 @@ $('.time').click(function () {
     view.timewindow($(this).attr("time")/24.0);
     powergraph_load(); powergraph_draw(); 
 });
-
-if (window.location.hash == "#power") {
-    show_powergraph();
-}
-
-function show_powergraph() {
-    view.timewindow(1.0);
-    $(".bargraph-navigation").hide();
-    viewmode = "powergraph";
-    powergraph_load();
-    powergraph_draw();
-    $(".powergraph-navigation").show();
-    $("#advanced-toggle").show();
-    $("#advanced-toggle").html("HIDE DETAIL");
-    $("#advanced-block").show();
-}
 
 $(".viewhistory").click(function () {
     $(".powergraph-navigation").hide();
@@ -475,7 +465,13 @@ $('.bargraph-alltime').click(function () {
 });
 
 $('.bargraph-day').click(function () {
-    show_powergraph();
+    view.timewindow(1.0);
+    $(".bargraph-navigation").hide();
+    viewmode = "powergraph";
+    powergraph_load();
+    powergraph_draw();
+    $(".powergraph-navigation").show();
+    $("#advanced-toggle").show();
 });
 
 $('.bargraph-week').click(function () {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -303,6 +303,18 @@ $('.time').click(function () {
     powergraph_load(); powergraph_draw(); 
 });
 
+if (window.location.hash == "#power") {
+    view.timewindow(1.0);
+    $(".bargraph-navigation").hide();
+    viewmode = "powergraph";
+    powergraph_load();
+    powergraph_draw();
+    $(".powergraph-navigation").show();
+    $("#advanced-toggle").show();
+    $("#advanced-toggle").html("HIDE DETAIL");
+    $("#advanced-block").show();
+}
+
 $(".viewhistory").click(function () {
     $(".powergraph-navigation").hide();
     var timeWindow = (3600000*24.0*30);
@@ -615,7 +627,6 @@ function powergraph_load()
             powergraph_series.push({label:"CH", data:remove_null_values(data["heatpump_ch"]), yaxis:4, color:"#FB6", lines:style});
         } else {
             powergraph_series.push({label:"CH", data:data["heatpump_ch"], yaxis:4, color:"#FB6", lines:style});
-        }
         }
     }
     if (feeds["heatpump_flowT"]!=undefined) { 

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -155,7 +155,7 @@ function show()
 
     // If this is a new dashboard there will be less than a days data 
     // show power graph directly in this case
-    if (((end*0.001)-start_time)<86400*3 || viewmode=="powergraph" || location.hash == "#power") {
+    if (((end*0.001)-start_time)<86400*3 || viewmode=="powergraph") {
         var timeWindow = (end - start_time*1000);
         if (timeWindow>(86400*3*1000)) timeWindow = 86400*1*1000;
         var start = end - timeWindow;
@@ -167,12 +167,6 @@ function show()
         $(".powergraph-navigation").show();
         powergraph_draw();
         $("#advanced-toggle").show();
-
-        if (location.hash == "#power") {
-          // auto-expand detail
-          $("#advanced-block").show();
-          $("#advanced-toggle").html("HIDE DETAIL");
-        }
     } else {
         var timeWindow = (3600000*24.0*30);
         var start = end - timeWindow;

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -603,9 +603,10 @@ function powergraph_load()
 
         let style = {lineWidth: 0, show:true, fill:0.15};
         if (all_same_interval) {
-            powergraph_series.push({label:"CH", data:remove_null_values(data["heatpump_ch"]), yaxis:4, color:"#FD8", lines:style});
+            powergraph_series.push({label:"CH", data:remove_null_values(data["heatpump_ch"]), yaxis:4, color:"#FB6", lines:style});
         } else {
-            powergraph_series.push({label:"CH", data:data["heatpump_ch"], yaxis:4, color:"#FD8", lines:style});
+            powergraph_series.push({label:"CH", data:data["heatpump_ch"], yaxis:4, color:"#FB6", lines:style});
+        }
         }
     }
     if (feeds["heatpump_flowT"]!=undefined) { 
@@ -1099,7 +1100,7 @@ function powergraph_draw()
         yaxes: [
             {min: 0, font: style,reserveSpace:false},
             {font: style,reserveSpace:false},
-            {font: style,reserveSpace:false},
+            {min: 0, font: {size:flot_font_size, color: "#44b3e2"},reserveSpace:false},
             {min: 0, max: 1, show: false, reserveSpace:false}
         ],
         grid: {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -476,6 +476,15 @@ $('.bargraph-month').click(function () {
     bargraph_draw();
 });
 
+$('.bargraph-year').click(function () {
+    var timeWindow = (3600000*24.0*365);
+    var end = (new Date()).getTime();
+    var start = end - timeWindow;
+    if (start<(start_time*1000)) start = start_time * 1000;
+    bargraph_load(start,end);
+    bargraph_draw();
+});
+
 $("#carnot_enable").click(function(){
 
     if ($("#carnot_enable_prc")[0].checked && !$("#carnot_enable")[0].checked) {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -1158,6 +1158,23 @@ function bargraph_load(start,end)
         for (var z in data["heatpump_elec_kwhd"]) {
             elec_kwh_in_window += data["heatpump_elec_kwhd"][z][1];
         }
+
+        // add series that shows COP points for each day
+        if (heat_enabled) {
+            cop_data = [];
+            for (var z in data["heatpump_elec_kwhd"]) {
+                time = data["heatpump_elec_kwhd"][z][0];
+                elec = data["heatpump_elec_kwhd"][z][1];
+                heat = data["heatpump_heat_kwhd"][z][1];
+                if (elec && heat) {
+                    cop_data[z] = [ time, heat / elec ];
+                }
+            }
+            bargraph_series.push({
+                data: cop_data, color: "#44b3e2", yaxis:3,
+                points: { show: true }
+            });
+        }
     }
     
     if (feeds["heatpump_outsideT"]!=undefined) {
@@ -1166,7 +1183,7 @@ function bargraph_load(start,end)
             data["heatpump_outsideT_daily"] = feed.getdata(feeds["heatpump_outsideT"].id,start,end,"daily",1,0);
             bargraph_series.push({
                 data: data["heatpump_outsideT_daily"], color: 4, yaxis:2,
-                lines: { show: true, align: "center", fill: false}, points: { show: true }
+                lines: { show: true, align: "center", fill: false}, points: { show: false }
             });
         }
     }
@@ -1197,6 +1214,10 @@ function bargraph_draw()
             // labelWidth:-5
             reserveSpace:false,
             // max:40
+        },{ 
+            font: {size:flot_font_size, color:"#44b3e2"}, 
+            reserveSpace:false,
+            min: 0
         }],
         selection: { mode: "x" },
         grid: {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -26,8 +26,8 @@ config.app = {
     "heatpump_outsideT":{"type":"feed", "autoname":"heatpump_outsideT", "engine":5, "optional":true, "description":"Outside temperature"},
     "heatpump_roomT":{"type":"feed", "autoname":"heatpump_roomT", "engine":5, "optional":true, "description":"Room temperature"},
     "heatpump_flowrate":{"type":"feed", "autoname":"heatpump_flowrate", "engine":5, "optional":true, "description":"Flow rate"},
-    "heatpump_dhw":{"type":"feed", "autoname":"heatpump_dhw", "optional":true, "description":"Heating Hot Water"},
-    "heatpump_ch":{"type":"feed", "autoname":"heatpump_ch", "optional":true, "description":"Central Heating"},
+    "heatpump_dhw":{"type":"feed", "autoname":"heatpump_dhw", "optional":true, "description":"Status of Hot Water circuit (non-zero when running)"},
+    "heatpump_ch":{"type":"feed", "autoname":"heatpump_ch", "optional":true, "description":"Status of Central Heating circuit (non-zero when running)"},
     "start_date":{"type":"value", "default":0, "name": "Start date", "description":_("Start date for all time values (unix timestamp)")},
 };
 config.feeds = feed.list();

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -304,6 +304,10 @@ $('.time').click(function () {
 });
 
 if (window.location.hash == "#power") {
+    show_powergraph();
+}
+
+function show_powergraph() {
     view.timewindow(1.0);
     $(".bargraph-navigation").hide();
     viewmode = "powergraph";
@@ -470,6 +474,10 @@ $('.bargraph-alltime').click(function () {
     bargraph_draw();
 });
 
+$('.bargraph-day').click(function () {
+    show_powergraph();
+});
+
 $('.bargraph-week').click(function () {
     var timeWindow = (3600000*24.0*7);
     var end = (new Date()).getTime();
@@ -479,8 +487,8 @@ $('.bargraph-week').click(function () {
     bargraph_draw();
 });
 
-$('.bargraph-quarter').click(function () {
-    var timeWindow = (3600000*24.0*91);
+$('.bargraph-month').click(function () {
+    var timeWindow = (3600000*24.0*30);
     var end = (new Date()).getTime();
     var start = end - timeWindow;
     if (start<(start_time*1000)) start = start_time * 1000;
@@ -488,8 +496,8 @@ $('.bargraph-quarter').click(function () {
     bargraph_draw();
 });
 
-$('.bargraph-month').click(function () {
-    var timeWindow = (3600000*24.0*30);
+$('.bargraph-quarter').click(function () {
+    var timeWindow = (3600000*24.0*91);
     var end = (new Date()).getTime();
     var start = end - timeWindow;
     if (start<(start_time*1000)) start = start_time * 1000;

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -66,8 +66,7 @@
     <div class="block-bound">
     
       <div class="bargraph-navigation">
-        <!--<div class="bluenav bargraph-other">OTHER</div>-->
-        <div class="bluenav bargraph-alltime">ALL TIME</div>
+        <div class="bluenav bargraph-alltime">ALL</div>
         <div class="bluenav bargraph-year">YEAR</div>
         <div class="bluenav bargraph-quarter">3 MONTHS</div>
         <div class="bluenav bargraph-month">MONTH</div>
@@ -87,8 +86,6 @@
         <span class="bluenav time" time='6' title="Last 6 hours">6</span>
         <span class="bluenav time" time='1' title="Last hour">H</span>
       </div>
-        
-      <div class="block-title">HISTORY</div>       
     </div>
     
     <div style="background-color:#fff; padding:10px;">

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -74,16 +74,16 @@
       </div>
       
       <div class="powergraph-navigation" style="display:none">
-        <div class="bluenav viewhistory">BACK</div>
-        <span class="bluenav" id="right" >></span>
-        <span class="bluenav" id="left" ><</span>
-        <span class="bluenav" id="zoomout" >-</span>
-        <span class="bluenav" id="zoomin" >+</span>
-        <span class="bluenav time dmy" time='720'>M</span>
-        <span class="bluenav time dmy" time='168'>W</span>
-        <span class="bluenav time" time='24'>D</span>
-        <span class="bluenav time" time='6'>6H</span>
-        <span class="bluenav time" time='1'>H</span>
+        <div class="bluenav viewhistory" title="Back to daily summary">BACK</div>
+        <span class="bluenav" id="right" title="Scroll right">&gt;</span>
+        <span class="bluenav" id="left" title="Scroll left">&lt;</span>
+        <span class="bluenav" id="zoomout" title="Zoom out">-</span>
+        <span class="bluenav" id="zoomin" title="Zoom in">+</span>
+        <span class="bluenav time dmy" time='720' title="Last 30 days">M</span>
+        <span class="bluenav time dmy" time='168' title="Last 7 days">W</span>
+        <span class="bluenav time" time='24' title="Last 24 hours">D</span>
+        <span class="bluenav time" time='6' title="Last 6 hours">6</span>
+        <span class="bluenav time" time='1' title="Last hour">H</span>
       </div>
         
       <div class="block-title">HISTORY</div>       

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -81,6 +81,7 @@
         <span class="bluenav time dmy" time='720'>M</span>
         <span class="bluenav time dmy" time='168'>W</span>
         <span class="bluenav time" time='24'>D</span>
+        <span class="bluenav time" time='6'>6H</span>
         <span class="bluenav time" time='1'>H</span>
       </div>
         

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -69,6 +69,7 @@
         <!--<div class="bluenav bargraph-other">OTHER</div>-->
         <div class="bluenav bargraph-alltime">ALL TIME</div>
         <div class="bluenav bargraph-year">YEAR</div>
+        <div class="bluenav bargraph-quarter">3 MONTHS</div>
         <div class="bluenav bargraph-month">MONTH</div>
         <div class="bluenav bargraph-week">WEEK</div>
       </div>

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -68,6 +68,7 @@
       <div class="bargraph-navigation">
         <!--<div class="bluenav bargraph-other">OTHER</div>-->
         <div class="bluenav bargraph-alltime">ALL TIME</div>
+        <div class="bluenav bargraph-year">YEAR</div>
         <div class="bluenav bargraph-month">MONTH</div>
         <div class="bluenav bargraph-week">WEEK</div>
       </div>

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -72,6 +72,7 @@
         <div class="bluenav bargraph-quarter">3 MONTHS</div>
         <div class="bluenav bargraph-month">MONTH</div>
         <div class="bluenav bargraph-week">WEEK</div>
+        <div class="bluenav bargraph-day">DAY</div>
       </div>
       
       <div class="powergraph-navigation" style="display:none">

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -100,10 +100,22 @@
         COP in window: <b id="window-cop"></b> <span id="window-carnot-cop"></span>
       </div>
     </div>
-          
+    
     <div id="advanced-block" style="background-color:#fff; padding:10px; display:none">
       <div style="color:#000">
-        <p id="show_flow_rate_bound" style="display:none"><b>Show flow rate:</b> <input id="show_flow_rate" type="checkbox" style="margin-top:-4px; margin-left:7px"></p>
+        <div id="dhw_stats" style="display: none">
+          <p><b>Heating</b>:
+          Electricity consumed: <span id="ch_elec_kwh"></span> kWh
+            &raquo; heat produced: <span id="ch_heat_kwh"></span> kWh
+            = COP <b><span id="ch_cop"></span></b>
+          </p>
+          <p><b>Hot Water</b>:
+          Electricity consumed: <span id="dhw_elec_kwh"></span> kWh
+            &raquo; heat produced: <span id="dhw_heat_kwh"></span> kWh
+            = COP <b><span id="dhw_cop"></span></b>
+          </p>
+        </div>
+        <hr style="margin:10px 0px 10px 0px">
       
         <table class="table">
           <tr>
@@ -118,19 +130,7 @@
           <tbody id="stats"></tbody>
         </table>
         
-        <div id="dhw_stats" style="display: none">
-          <hr style="margin:10px 0px 10px 0px">
-          <p><b>Heating</b>:
-            Electricity consumed: <span id="ch_elec_kwh"></span> kWh
-            &raquo; heat produced: <span id="ch_heat_kwh"></span> kWh
-            = COP <b><span id="ch_cop"></span></b>
-          </p>
-          <p><b>Hot Water</b>:
-            Electricity consumed: <span id="dhw_elec_kwh"></span> kWh
-            &raquo; heat produced: <span id="dhw_heat_kwh"></span> kWh
-            = COP <b><span id="dhw_cop"></span></b>
-          </p>
-        </div>
+        <p id="show_flow_rate_bound" style="display:none"><b>Show flow rate:</b> <input id="show_flow_rate" type="checkbox" style="margin-top:-4px; margin-left:7px"></p>
         
         <hr style="margin:10px 0px 10px 0px">
         <p><b>Standby</b></p>


### PR DESCRIPTION
As requested by Zarch, moved the heating/dhw stats to be just below the main COP number.

* moved "Show flow rate" down below the main stats table.
* fixed the legend from wrapping onto two lines (bug mentioned by Zarch)
* added extra navigation buttons to both barchart and powerchart
* tweaked some colours for clarity, including COP axis
* added COP points to history barchart

### Heating and hot water stats

![image](https://github.com/emoncms/app/assets/75039652/b3fa2d2e-6eda-48c8-9b94-221066372f64)

### Nav bars:

![image](https://github.com/emoncms/app/assets/75039652/fd850841-e1f9-43c6-8a38-ed9645a347d9)

![image](https://github.com/emoncms/app/assets/75039652/b9b1e9ce-08d5-4473-a0d1-04f0303efa8e)

### Daily COP

![image](https://github.com/emoncms/app/assets/75039652/46789011-fd15-4d63-90a9-f778859d7a0b)
