### PR TITLE
Further tweaks for My Heatpump app

### DIFF
--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -944,6 +944,7 @@ function powergraph_load()
     var standby_kwh = 0;
     if (data["heatpump_elec"]!=undefined) {
         for (var z in data["heatpump_elec"]) {
+            if (data["heatpump_elec"][z][0]>=now) break;
             if (data["heatpump_elec"][z][1]!=null) power = data["heatpump_elec"][z][1];
             if (power<starting_power) {
                 standby_kwh += power * view.interval / 3600000;
@@ -960,6 +961,7 @@ function powergraph_load()
             var power = 0
             var dhw = 0
             for (var z in data["heatpump_elec"]) {
+                if (data["heatpump_elec"][z][0]>=now) break;
                 if (data["heatpump_elec"][z][1]!=null) power = data["heatpump_elec"][z][1];
                 if (data["heatpump_dhw"][z][1]!=null) dhw = data["heatpump_dhw"][z][1];
                 if (dhw) {
@@ -974,6 +976,7 @@ function powergraph_load()
             var heat = 0
             var dhw = 0
             for (var z in data["heatpump_heat"]) {
+                if (data["heatpump_heat"][z][0]>=now) break;
                 if (data["heatpump_heat"][z][1]!=null) heat = data["heatpump_heat"][z][1];
                 if (data["heatpump_dhw"][z][1]!=null) dhw = data["heatpump_dhw"][z][1];
                 if (dhw) {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -284,6 +284,20 @@ function updater()
             if (feeds["heatpump_elec"]==undefined) $("#heatpump_elec").html(Math.round(elec*HOUR/(60*30)));
             if (feeds["heatpump_heat"]==undefined) $("#heatpump_heat").html(Math.round(heat*HOUR/(60*30)));
             
+            // update power chart if showing up to last 5 minutes, and less than 48 hours
+            if (viewmode=="powergraph") {
+                var timeWindow = (view.end - view.start);
+                if (view.end > progtime - 5*MINUTE && timeWindow <= 2*DAY) {
+                    if (view.end < now) {
+                        // automatically scroll power chart if at the end
+                        view.end = now;
+                        view.start = view.end - timeWindow;
+                    }
+
+                    powergraph_load();
+                    powergraph_draw();
+                }
+            }
             progtime = now;
         }
         
@@ -1182,6 +1196,17 @@ function powergraph_draw()
     }
     if ($('#placeholder').width()) {
         $.plot($('#placeholder'),powergraph_series,options);
+    }
+
+    // show symbol when live scrolling is active
+    var now = new Date().getTime();
+    if (view.end > now - 5*MINUTE && view.end <= now + 5*MINUTE && view.end - view.start <= 2*DAY) {
+        $('#right').hide();
+        $('#live').show();
+    }
+    else {
+        $('#live').hide();
+        $('#right').show();
     }
 }
 

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -25,6 +25,7 @@ config.app = {
     "heatpump_returnT":{"type":"feed", "autoname":"heatpump_returnT", "engine":5, "optional":true, "description":"Return temperature"},
     "heatpump_outsideT":{"type":"feed", "autoname":"heatpump_outsideT", "engine":5, "optional":true, "description":"Outside temperature"},
     "heatpump_roomT":{"type":"feed", "autoname":"heatpump_roomT", "engine":5, "optional":true, "description":"Room temperature"},
+    "heatpump_targetT":{"type":"feed", "autoname":"heatpump_targetT", "optional":true, "description":"Target (Room or Flow) Temperature"},
     "heatpump_flowrate":{"type":"feed", "autoname":"heatpump_flowrate", "engine":5, "optional":true, "description":"Flow rate"},
     "heatpump_dhw":{"type":"feed", "autoname":"heatpump_dhw", "optional":true, "description":"Status of Hot Water circuit (non-zero when running)"},
     "heatpump_ch":{"type":"feed", "autoname":"heatpump_ch", "optional":true, "description":"Status of Central Heating circuit (non-zero when running)"},
@@ -423,6 +424,7 @@ $('#placeholder').bind("plothover", function (event, pos, item) {
                 else if (item.series.label=="ReturnT") { name = "ReturnT"; unit = "°C"; dp = 1; }
                 else if (item.series.label=="OutsideT") { name = "Outside"; unit = "°C"; dp = 1; }
                 else if (item.series.label=="RoomT") { name = "Room"; unit = "°C"; dp = 1; }
+                else if (item.series.label=="TargetT") { name = "Target"; unit = "°C"; dp = 1; }
                 else if (item.series.label=="DHW") { name = "Hot Water"; unit = ""; dp = 0; }
                 else if (item.series.label=="CH") { name = "Central Heating"; unit = ""; dp = 0; }
                 else if (item.series.label=="Electric") { name = "Elec"; unit = "W"; }
@@ -654,6 +656,15 @@ function powergraph_load()
             powergraph_series.push({label:"CH", data:remove_null_values(data["heatpump_ch"]), yaxis:4, color:"#FB6", lines:style});
         } else {
             powergraph_series.push({label:"CH", data:data["heatpump_ch"], yaxis:4, color:"#FB6", lines:style});
+        }
+    }
+    if (feeds["heatpump_targetT"]!=undefined) {
+        data["heatpump_targetT"] = feed.getdata(feeds["heatpump_targetT"].id,view.start,view.end,view.interval,1,0,skipmissing,limitinterval);
+
+        if (all_same_interval) {
+            powergraph_series.push({label:"TargetT", data:remove_null_values(data["heatpump_targetT"]), yaxis:2, color:"#ccc"});
+        } else {
+            powergraph_series.push({label:"TargetT", data:data["heatpump_targetT"], yaxis:2, color:"#ccc"});
         }
     }
     if (feeds["heatpump_flowT"]!=undefined) { 
@@ -1006,6 +1017,7 @@ function powergraph_load()
     feedstats["heatpump_returnT"] = stats(data["heatpump_returnT"]);
     if (data["heatpump_outsideT"]!=undefined) feedstats["heatpump_outsideT"] = stats(data["heatpump_outsideT"]);
     if (data["heatpump_roomT"]!=undefined) feedstats["heatpump_roomT"] = stats(data["heatpump_roomT"]);
+    if (data["heatpump_targetT"]!=undefined) feedstats["heatpump_targetT"] = stats(data["heatpump_targetT"]);
     if (data["heatpump_flowrate"]!=undefined) feedstats["heatpump_flowrate"] = stats(data["heatpump_flowrate"]);
     
     if (feedstats["heatpump_elec"].mean>0) {
@@ -1068,6 +1080,7 @@ function powergraph_load()
       "heatpump_returnT":"Return temperature",
       "heatpump_outsideT":"Outside temperature",
       "heatpump_roomT":"Room temperature",
+      "heatpump_targetT":"Target temperature",
       "heatpump_flowrate":"Flow rate"
     }
     
@@ -1177,7 +1190,7 @@ function powergraph_draw()
             margin:{top:30}
         },
         selection: { mode: "x" },
-        legend:{position:"NW", noColumns:10}
+        legend:{position:"NW", noColumns:13}
     }
     if ($('#placeholder').width()) {
         $.plot($('#placeholder'),powergraph_series,options);

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -1288,7 +1288,7 @@ function bargraph_draw()
             reserveSpace:false,
             min:0
         },{ 
-            font: {size:flot_font_size, color:"#666"}, 
+            font: {size:flot_font_size, color:"#9440ed"}, 
             // labelWidth:-5
             reserveSpace:false,
             // max:40

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -160,7 +160,19 @@ function show()
             $("#advanced-block").show();
             $("#advanced-toggle").html("HIDE DETAIL");
         }
-    }    
+        if (urlParams.cop) {
+            $("#show_instant_cop").click();
+            show_instant_cop = true;
+        }
+        if (urlParams.flow) {
+            $("#show_flow_rate").click();
+            show_flow_rate = true;
+        }
+        if (urlParams.carnot) {
+            $("#carnot_enable")[0].click();
+            $("#heatpump_factor").val(urlParams.carnot);
+        }
+    }
 
     // If this is a new dashboard there will be less than a days data 
     // show power graph directly in this case
@@ -1358,6 +1370,16 @@ function set_url_view_params(mode,start,end) {
     url.searchParams.set('mode', mode); 
     url.searchParams.set('start', Math.round(start*0.001));
     url.searchParams.set('end', Math.round(end*0.001));
+
+    if (show_instant_cop) url.searchParams.set('cop', 1); 
+    else url.searchParams.delete('cop');
+
+    if (show_flow_rate) url.searchParams.set('flow', 1); 
+    else url.searchParams.delete('flow');
+    
+    if ($("#carnot_enable")[0].checked) url.searchParams.set('carnot', parseFloat($("#heatpump_factor").val())); 
+    else url.searchParams.delete('carnot');
+
     $('#permalink')[0].href = url.toString();
 }
 

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -498,7 +498,13 @@ $('.bargraph-day').click(function () {
     powergraph_load();
     powergraph_draw();
     $(".powergraph-navigation").show();
+    
     $("#advanced-toggle").show();
+    if ($("#advanced-toggle").html()=="SHOW DETAIL") {
+        $("#advanced-block").hide();
+    } else {
+        $("#advanced-block").show();
+    }  
 });
 
 $('.bargraph-week').click(function () {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -637,7 +637,7 @@ function powergraph_load()
     powergraph_series = [];
 
     if (feeds["heatpump_dhw"]!=undefined) {
-        data["heatpump_dhw"] = feed.getdata(feeds["heatpump_dhw"].id,view.start,view.end,view.interval,0,0,skipmissing,limitinterval);
+        data["heatpump_dhw"] = feed.getdata(feeds["heatpump_dhw"].id,view.start,view.end,view.interval,1,0,skipmissing,limitinterval);
 
         let style = {lineWidth: 0, show:true, fill:0.15};
         if (all_same_interval) {
@@ -647,7 +647,7 @@ function powergraph_load()
         }
     }
     if (feeds["heatpump_ch"]!=undefined) {
-        data["heatpump_ch"] = feed.getdata(feeds["heatpump_ch"].id,view.start,view.end,view.interval,0,0,skipmissing,limitinterval);
+        data["heatpump_ch"] = feed.getdata(feeds["heatpump_ch"].id,view.start,view.end,view.interval,1,0,skipmissing,limitinterval);
 
         let style = {lineWidth: 0, show:true, fill:0.15};
         if (all_same_interval) {

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -135,19 +135,17 @@ function show()
     resize();
     
     var date = new Date();
-
     var now = date.getTime();
     
     end = end_time*1000;
     
-    date.setTime(end);
-    
     if ((now-end)>3600*1000) {
         $("#last_updated").show();
         $("#live_table").hide();
+        date.setTime(end);
         let h = date.getHours();
-        if (h<10) h = "0"+h;
         let m = date.getMinutes();
+        if (h<10) h = "0"+h;
         if (m<10) m = "0"+m;
         $("#last_updated").html("Last updated: "+date.toDateString()+" "+h+":"+m)
     } else {
@@ -220,9 +218,6 @@ function clear()
 
 function updater()
 {
-
-
-
     feed.listbyidasync(function(result){
         if (result === null) { return; }
         
@@ -270,34 +265,20 @@ function updater()
         
         // Updates every 60 seconds
         if (progtime%60==0) {
-        
-            if (feeds["heatpump_elec"]!=undefined) {
-                var min30 = feeds["heatpump_elec"].time - (60*30);
-                var min60 = feeds["heatpump_elec"].time - (60*60);
-            } else {
-                var min30 = feeds["heatpump_elec_kwh"].time - (60*30);
-                var min60 = feeds["heatpump_elec_kwh"].time - (60*60);
-            }
-            
             var elec = 0; var heat = 0;
-            // if (elec_enabled) elec = feeds["heatpump_elec_kwh"].value - feed.getvalue(feeds["heatpump_elec_kwh"].id, min30);
-            // if (heat_enabled) heat = feeds["heatpump_heat_kwh"].value - feed.getvalue(feeds["heatpump_heat_kwh"].id, min30);
-
             if (elec_enabled) elec = get_average("heatpump_elec",1800);
             if (heat_enabled) heat = get_average("heatpump_heat",1800);
             
-            
             var COP = 0;
-            if (elec>0) COP = heat / elec;
-            if (COP<0) COP =0;
+            if (elec>0 && heat>0) COP = heat / elec;
             if (realtime_cop_div_mode=="30min") {
                 $("#realtime_cop_value").html(COP.toFixed(2));
             }
             
             if (feeds["heatpump_elec"]==undefined) $("#heatpump_elec").html(Math.round(elec*3600000/(60*30)));
-            if (feeds["heatpump_elec"]==undefined) $("#heatpump_heat").html(Math.round(heat*3600000/(60*30)));
+            if (feeds["heatpump_heat"]==undefined) $("#heatpump_heat").html(Math.round(heat*3600000/(60*30)));
         }
-        progtime += 5;
+        progtime += 10;
         
         //$(".value1").css("color","#00cc00");
         //setTimeout(function(){ $(".value1").css("color","#333"); },400);

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -963,7 +963,7 @@ function powergraph_load()
             for (var z in data["heatpump_elec"]) {
                 if (data["heatpump_elec"][z][0]>=now) break;
                 if (data["heatpump_elec"][z][1]!=null) power = data["heatpump_elec"][z][1];
-                if (data["heatpump_dhw"][z][1]!=null) dhw = data["heatpump_dhw"][z][1];
+                if (data["heatpump_dhw"][z] && data["heatpump_dhw"][z][1]!=null) dhw = data["heatpump_dhw"][z][1];
                 if (dhw) {
                     dhw_elec_kwh += power * view.interval / 3600000;
                 }
@@ -978,7 +978,7 @@ function powergraph_load()
             for (var z in data["heatpump_heat"]) {
                 if (data["heatpump_heat"][z][0]>=now) break;
                 if (data["heatpump_heat"][z][1]!=null) heat = data["heatpump_heat"][z][1];
-                if (data["heatpump_dhw"][z][1]!=null) dhw = data["heatpump_dhw"][z][1];
+                if (data["heatpump_dhw"][z] && data["heatpump_dhw"][z][1]!=null) dhw = data["heatpump_dhw"][z][1];
                 if (dhw) {
                     dhw_heat_kwh += heat * view.interval / 3600000;
                 }

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -156,7 +156,7 @@
         <div class="input-prepend input-append" style="margin-top:5px">
           <span class="add-on">Valid COP</span>
           <span class="add-on">Min</span>
-          <input type="text" style="width:50px" id="inst_cop_min" value="2.0">
+          <input type="text" style="width:50px" id="inst_cop_min" value="1.0">
           <span class="add-on">Max</span>
           <input type="text" style="width:50px" id="inst_cop_max" value="8.0">
         </div>

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -142,6 +142,13 @@
           <input type="text" style="width:50px" id="starting_power" value="100">
         </div>
 
+        <p><b>Show mean values for periods when heat pump is running only:</b>
+          <input id="stats_when_running" type="checkbox" style="margin-top:-4px; margin-left:7px">
+          <span id="stats_without_dhw" style="display: none;"> - <i>Exclude DHW:</i> <input id="exclude_dhw" type="checkbox" style="margin-top:-4px; margin-left:7px"></span>
+          <br><span style="font-size:12px">(Based on starting power value above)</span></p>
+
+        <div id="mean_when_running"></div>
+        
         <hr style="margin:10px 0px 10px 0px">
 
         <p><b>Show Instantaneous COP:</b> <input id="show_instant_cop" type="checkbox" style="margin-top:-4px; margin-left:7px"></p>
@@ -162,15 +169,6 @@
             <option value="5">5 points</option>
           </select>
         </div>
-
-        <hr style="margin:10px 0px 10px 0px">
-        
-        <p><b>Show mean values for periods when heat pump is running only:</b>
-          <input id="stats_when_running" type="checkbox" style="margin-top:-4px; margin-left:7px">
-          <span id="stats_without_dhw" style="display: none;"> - <i>Exclude DHW:</i> <input id="exclude_dhw" type="checkbox" style="margin-top:-4px; margin-left:7px"></span>
-          <br><span style="font-size:12px">(Based on starting power value above)</span></p>
-
-        <div id="mean_when_running"></div>
         
         <hr style="margin:10px 0px 10px 0px">
         
@@ -268,4 +266,4 @@ var session_write = <?php echo $session['write']; ?>;
 config.name = "<?php echo $name; ?>";
 config.db = <?php echo json_encode($config); ?>;
 </script>
-<script type="text/javascript" src="<?php echo $path; ?>Modules/app/apps/OpenEnergyMonitor/myheatpump/myheatpump.js?v=72"></script>
+<script type="text/javascript" src="<?php echo $path; ?>Modules/app/apps/OpenEnergyMonitor/myheatpump/myheatpump.js?v=73"></script>

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -76,6 +76,7 @@
       
       <div class="powergraph-navigation" style="display:none">
         <div class="bluenav viewhistory" title="Back to daily summary">BACK</div>
+        <span class="bluenav" id="live" title="Live scroll" style="display:none; color: yellow; cursor: default">&gt;&gt;</span>
         <span class="bluenav" id="right" title="Scroll right">&gt;</span>
         <span class="bluenav" id="left" title="Scroll left">&lt;</span>
         <span class="bluenav" id="zoomout" title="Zoom out">-</span>


### PR DESCRIPTION
Fixed a couple issues reported by community, and added some new features:

* :zap: automatic update and scrolling of power graph, to show live data 
* :link: extended shared URLs to include flow, cop and carnot
* :thermometer: added `heatpump_targetT` for showing target room or flow temperature