### PR TITLE
Battery Simulator: Stop charging at the end of the off-peak (fix #200)

### DIFF
--- a/apps/OpenEnergyMonitor/solarbatterysim/solarbatterysim.php
+++ b/apps/OpenEnergyMonitor/solarbatterysim/solarbatterysim.php
@@ -512,7 +512,7 @@ function process_month(d) {
         // Charging when there is excess solar 
         if (solar>use) charge = solar-use;
         // Offpeak / night time charge
-        if (charging_offpeak) charge = input.battery_max_charge_rate;
+        if (charging_offpeak && offpeak) charge = input.battery_max_charge_rate;
         
         if (charge>0) {
             if (charge>input.battery_max_charge_rate) charge = input.battery_max_charge_rate;


### PR DESCRIPTION
Only use the desired charge rate for off-peak charging when within the off-peak period. This means we don't hit the desired SOC but don't import more expensive electricity.

Tests:
 - Verified with lower 1kW charge rate SOC only gets to ~50%
 - Verified with 3kW charge rate, SOC reaches 100% and which is maintained until end of off-peak period and discharge starts