### PR TITLE
Add DHW data to myheatpump app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -38,6 +38,10 @@ config.app = {
     "immersion_elec": { "type": "feed", "autoname": "immersion_elec", "optional": true, "description": "Immersion electric use in watts" },
     // "immersion_elec_kwh": { "type": "feed", "autoname": "immersion_elec_kwh", "optional": true, "description": "Immersion electric use kWh" },
 
+    // DHW
+    "heatpump_dhwT": { "type": "feed", "autoname": "heatpump_dhwT", "optional": true, "description": "Domestic Hot Water temperature" },
+    "heatpump_dhwTargetT": { "type": "feed", "autoname": "heatpump_dhwTargetT", "optional": true, "description": "Target DHW Temperature" },
+    
     // Other
     "starting_power": { "type": "value", "default": 150, "name": "Starting power", "description": "Starting power of heatpump in watts" },
     "auto_detect_cooling":{"type":"checkbox", "default":false, "name": "Auto detect cooling", "description":"Auto detect summer cooling if cooling status feed is not present"},

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -89,6 +89,8 @@ var show_defrost_and_loss = false;
 var show_cooling = false;
 var emitter_spec_enable = false;
 
+var show_dhw_temp = false
+
 var bargraph_start = 0;
 var bargraph_end = 0;
 var last_bargraph_start = 0;
@@ -140,6 +142,10 @@ function show() {
 
     if (feeds["heatpump_flowrate"] != undefined) {
         $("#show_flow_rate_bound").show();
+    }
+
+    if (feeds["heatpump_dhwT"] != undefined) {
+        $("#show_dhw_temp_bound").show();
     }
 
     if (feeds["immersion_elec"] != undefined) {
@@ -578,4 +584,15 @@ $("#clear-daily-data").click(function () {
             }
         }
     });
+});
+
+$("#show_dhw_temp").click(function () {
+    if ($("#show_dhw_temp")[0].checked) {
+        show_dhw_temp = true;
+    } else {
+        show_dhw_temp = false;
+    }
+    if (viewmode == "powergraph") {
+        powergraph_draw();
+    }
 });

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.php
@@ -189,7 +189,10 @@ global $path, $session, $v;
               <input id="show_flow_rate" type="checkbox" class="advanced-options-checkbox">
               <b>Show flow rate</b>
             </div>
-
+            <div id="show_dhw_temp_bound" style="display:none" class="advanced-options">
+              <input id="show_dhw_temp" type="checkbox" class="advanced-options-checkbox">
+              <b>Show DHW temperature</b>
+            </div>
             <div id="show_cooling_bound" class="advanced-options">
               <div style="float:right"><span id="total_defrost_and_loss_kwh"></span> kWh (<span id="prc_defrost_and_loss"></span>%)</div>
               <input id="show_defrost_and_loss" type="checkbox" class="advanced-options-checkbox">

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump_controller.php
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump_controller.php
@@ -76,7 +76,9 @@ function myheatpump_app_controller($route,$app,$appconfig,$apikey)
                 "heatpump_outsideT",
                 "heatpump_dhw",
                 "heatpump_ch",
-                "heatpump_targetT"
+                "heatpump_targetT",
+                "heatpump_dhwT",
+                "heatpump_dhwTargetT",
             );
 
             require_once "Modules/feed/feed_model.php";

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump_powergraph.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump_powergraph.js
@@ -515,7 +515,8 @@ function powergraph_draw() {
             let show = true;
             if (key == 'heatpump_flowrate' && !show_flow_rate) show = false;
             if (key == 'immersion_elec' && !show_immersion) show = false;
-
+            if (key == 'heatpump_dhwT' && !show_dhw_temp) show = false;
+            if (key == 'heatpump_dhwTargetT' && !show_dhw_temp) show = false;
             if (show) powergraph_series_without_key.push(powergraph_series[key]);
         }
         $.plot($('#placeholder'), powergraph_series_without_key, options);

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump_powergraph.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump_powergraph.js
@@ -30,7 +30,9 @@ function powergraph_load() {
         "heatpump_flowrate": { label: "Flow rate", yaxis: 3, color: 6 },
         "heatpump_heat": { label: "Heat", yaxis: 1, color: 0, lines: { show: true, fill: 0.2, lineWidth: 0.5 } },
         "heatpump_elec": { label: "Electric", yaxis: 1, color: 1, lines: { show: true, fill: 0.3, lineWidth: 0.5 } },
-        "immersion_elec": { label: "Immersion", yaxis: 1, color: 4, lines: { show: true, fill: 0.3, lineWidth: 0.5 } }
+        "immersion_elec": { label: "Immersion", yaxis: 1, color: 4, lines: { show: true, fill: 0.3, lineWidth: 0.5 } },
+        "heatpump_dhwT": { label: "DHW T", yaxis: 2, color: "#0080ff" },
+        "heatpump_dhwTargetT": { label: "DHW TargetT", yaxis: 2, color:"#99cbfc" },
     }
 
     // Compile list of feedids
@@ -79,6 +81,17 @@ function powergraph_load() {
                 targetT = data["heatpump_targetT"][z][1];
             } else {
                 data["heatpump_targetT"][z][1] = targetT;
+            }
+        } 
+        
+        // Process heatpump_dhwTargetT data
+        // replace null values with the last known value
+        var targetT = null;
+        for (var z in data["heatpump_dhwTargetT"]) {
+            if (data["heatpump_dhwTargetT"][z][1] != null) {
+                targetT = data["heatpump_dhwTargetT"][z][1];
+            } else {
+                data["heatpump_dhwTargetT"][z][1] = targetT;
             }
         }
 
@@ -610,7 +623,8 @@ function powergraph_tooltip(item) {
         dp = 3;
     }
     else if (item.series.label == "Immersion") { name = "Immersion"; unit = "W"; }
-
+    else if (item.series.label == "DHW T") { name = "DHW T"; unit = "°C"; dp = 1; }
+    else if (item.series.label == "DHW TargetT") { name = "DHW Target T"; unit = "°C"; dp = 1; }
     tooltip(item.pageX, item.pageY, name + " " + itemValue.toFixed(dp) + unit + "<br>" + date + ", " + time, "#fff", "#000");
 }
 

--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump_process.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump_process.js
@@ -194,7 +194,9 @@ function process_stats() {
         "heatpump_outsideT": { name: "Outside temperature", unit: "°C", dp: 1 },
         "heatpump_roomT": { name: "Room temperature", unit: "°C", dp: 1 },
         "heatpump_targetT": { name: "Target temperature", unit: "°C", dp: 1 },
-        "heatpump_flowrate": { name: "Flow rate", unit: "", dp: 3 }
+        "heatpump_flowrate": { name: "Flow rate", unit: "", dp: 3 },
+        "heatpump_dhwT": { name: "DHW temperature", unit: "°C", dp: 1 },
+        "heatpump_dhwTargetT": { name: "DHW target temperature", unit: "°C", dp: 1 }
     }
 
     var keys = [];


### PR DESCRIPTION
I added the ability to add feeds for DHW & DHW target temperature into the myheatpump app.

![image](https://github.com/user-attachments/assets/4e2aed62-3e47-4a26-9f50-ab03bbce2afc)

There is also an added .gitattributes file - I needed to add this to ensure proper cross-platform development on windows devcontainers within VSCode.