### PR TITLE
Add DHW temperature parameter to share URL

### DIFF
--- a/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
+++ b/apps/OpenEnergyMonitor/myheatpump/myheatpump.js
@@ -242,6 +242,10 @@ function show() {
             $("#show_flow_rate").click();
             show_flow_rate = true;
         }
+        if (urlParams.dhw) {
+            $("#show_dhw_temp").click();
+            show_dhw_temp = true;
+        }
         if (urlParams.carnot) {
             $("#carnot_enable")[0].click();
             $("#heatpump_factor").val(urlParams.carnot);
@@ -494,6 +498,9 @@ function set_url_view_params(mode, start, end) {
 
     if (show_flow_rate) url.searchParams.set('flow', 1);
     else url.searchParams.delete('flow');
+
+    if (show_dhw_temp) url.searchParams.set('dhw', 1);
+    else url.searchParams.delete('dhw');
 
     if (show_defrost_and_loss) url.searchParams.set('cool', 1);
     else url.searchParams.delete('cool');


### PR DESCRIPTION
## Summary
- Add `dhw=1` to the MyHeatpump share permalink when "Show DHW temperature/charge" is checked
- Restore DHW visibility when opening a shared link with `dhw=1` in the URL
- Mirrors the existing `flow=1` behaviour for flow rate

Fixes openenergymonitor/heatpumpmonitor.org#86
